### PR TITLE
chore: add build script (#4)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
         with:
           node-version: "14"
       - uses: bahmutov/npm-install@v1
+      - run: yarn test
       - run: yarn release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: Tests
+
+on: push
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+      - uses: bahmutov/npm-install@v1
+      - run: yarn test
+      - run: yarn build

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     ]
   },
   "scripts": {
+    "test": "yarn workspaces run test",
+    "build": "yarn workspaces run build",
     "release": "multi-semantic-release"
   },
   "devDependencies": {

--- a/packages/package-1/package.json
+++ b/packages/package-1/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@angeloashmore/multi-semantic-release-test-1",
   "version": "1.0.0-unstable.1",
+  "scripts": {
+    "build": "echo \"Simulating a build\" && exit 0",
+    "test": "echo \"Simulating a test\" && exit 0"
+  },
   "repository": {
     "type": "git",
     "url": "git@github.com:angeloashmore/multi-semantic-release-test.git"

--- a/packages/package-2/package.json
+++ b/packages/package-2/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@angeloashmore/multi-semantic-release-test-2",
   "version": "1.0.0-unstable.1",
+  "scripts": {
+    "build": "echo \"Simulating a build\" && exit 0",
+    "test": "echo \"Simulating a test\" && exit 0"
+  },
   "repository": {
     "type": "git",
     "url": "git@github.com:angeloashmore/multi-semantic-release-test.git"


### PR DESCRIPTION
* chore: remove release dry-run flag

* chore(release): 1.0.0-unstable.1

# @angeloashmore/multi-semantic-release-test-1 1.0.0-unstable.1 (2021-04-27)

### Features

* initial commit ([70bae1c](https://github.com/angeloashmore/multi-semantic-release-test/commit/70bae1c7c91245d9a2028c014209cf1730e4a31c))

 [skip ci]

* chore: add access=public npm config

* chore(release): 1.0.0-unstable.1

# @angeloashmore/multi-semantic-release-test-2 1.0.0-unstable.1 (2021-04-27)

### Features

* initial commit ([70bae1c](https://github.com/angeloashmore/multi-semantic-release-test/commit/70bae1c7c91245d9a2028c014209cf1730e4a31c))

 [skip ci]

* test: add failing fake test

* chore: run test before release

* chore: add test workflow

* test: fix failing test

* chore: add build script

Co-authored-by: semantic-release-bot <semantic-release-bot@martynus.net>